### PR TITLE
Change Robz8 to RocketRobz

### DIFF
--- a/_pages/en_US/credits.md
+++ b/_pages/en_US/credits.md
@@ -12,7 +12,7 @@ If I forgot you here, contact me and I'll add your name.
     + jerbear64
     + pokecraft98
     + emiyl
-    + Robz8
+    + RocketRobz
     + Jhynjhiruu
     + GhostLatte
     + HamBone41801

--- a/_pages/en_US/finalizing-setup.md
+++ b/_pages/en_US/finalizing-setup.md
@@ -12,7 +12,7 @@ TWiLight Menu++ is a homebrew application that can launch homebrew and retail RO
 
 ## Downloads
 
-- The latest release of [TWiLight Menu++](https://github.com/Robz8/TWiLightMenu/releases){:target="_blank"}
+- The latest release of [TWiLight Menu++](https://github.com/RocketRobz/TWiLightMenu/releases){:target="_blank"}
 
 ## Instructions
 

--- a/_pages/en_US/installing-hiyacfw.md
+++ b/_pages/en_US/installing-hiyacfw.md
@@ -26,7 +26,7 @@ HiyaCFW has several advantages that only having Unlaunch on your system will not
   - Windows users will need to install [WinFsp](http://www.secfs.net/winfsp/download/){:target="_blank"} as well
 - The latest release of [OSFMount](https://www.osforensics.com/tools/mount-disk-images.html){:target="_blank"}
   - This can be substituted for the `mount` utility on non-Windows systems
-- The latest release of [HiyaCFW](https://github.com/Robz8/hiyaCFW/releases){:target="_blank"}
+- The latest release of [HiyaCFW](https://github.com/RocketRobz/hiyaCFW/releases){:target="_blank"}
 - [NUSDownloader](/assets/files/NUSDownloader.zip)
 - A NAND backup taken from your device, with the NO$GBA Footer
   - fwTool 2.0 will create this footer automatically when it makes a backup

--- a/_pages/en_US/replacing-system-menu-with-twlmenu++.md
+++ b/_pages/en_US/replacing-system-menu-with-twlmenu++.md
@@ -21,7 +21,7 @@ Replacing the System Menu with TWiLight Menu++ will allow for a few advantages o
 In this configuration, TWiLight Menu++ is effectively acting as an open source alternative to the System Menu.
 
 ## Downloads
-- The latest release of [TWiLight Menu++](https://github.com/Robz8/TWiLightMenu/releases){:target="_blank"}
+- The latest release of [TWiLight Menu++](https://github.com/RocketRobz/TWiLightMenu/releases){:target="_blank"}
 - [launcharggen](/assets/files/launcharggen.zip)
   - Windows users may use the .EXE
   - Users of other operating systems may use the .py (requires [Python 2 or 3](https://www.python.org/downloads/){:target="_blank"})


### PR DESCRIPTION
The links to Robz's GitHub (Hiya and TWLMenu) aren't working anymore because of his username change, so it just says that there are no releases... This updates the links to his new username