### PR TITLE
Update to have an option to not install HiyaCFW

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -121,4 +121,4 @@ DEPENDENCIES
   rake (~> 10.0)
 
 BUNDLED WITH
-   1.16.2
+   2.0.2

--- a/_pages/en_US/home.md
+++ b/_pages/en_US/home.md
@@ -19,7 +19,7 @@ Thoroughly read all of the introductory pages (including this one!) before proce
 
 {% capture notice-1 %}
 This guide is available in other languages!
-Click the <i class="fa fa-language" aria-hidden="true"></i> icon at the top right of the page to change the language.    
+Click the <i class="fa fa-language" aria-hidden="true"></i> icon at the top right of the page to change the language.
 Alternatively, click [here](https://crowdin.com/project/dsi-guide) to help to keep these translations up to date.
 {% endcapture %}
 
@@ -33,9 +33,11 @@ Homebrew can be run for free on any DSi system, regardless of firmware version o
 
 ## What does this guide install?
 
-This guide will install HiyaCFW, a custom firmware for the DSi. CFW can be set up on any console on any version.
+This guide will install HiyaCFW, a custom firmware for the DSi, and/or TWiLight Menu++, a homebrew home menu replacement. TWiLight Menu++ and HiyaCFW can both be set up on any console on any version.
 
 Custom firmware enables you to use more advanced hacks that userland homebrew can’t easily do. For instance, signature patches let you install unsigned titles that appear right on your System Menu.
+
+TWiLight Menu++ is a homebrew that functions as a complete home menu replacement with many additional features such as rom loading and custom themes.
 
 ## What should I know before starting?
 
@@ -50,10 +52,10 @@ There are currently two methods of running homebrew, and therefore running custo
 - Memory Pit, a DSi Camera exploit for all retail systems, firmware versions, and regions
 - Flipnote Lenny, a firmware-agnostic Flipnote exploit that can't be used unless you already have it due to DSi Shop closure
 
-Memory Pit is the easiest and most widely available exploit to set up, and is the default method of this guide.  
+Memory Pit is the easiest and most widely available exploit to set up, and is the default method of this guide.
 Continue to [Installing Unlaunch](installing-unlaunch)
 {: .notice--info}
-However, if for whatever reason you have a functional copy of Flipnote Studio and prefer use it instead of DSi Camera, you may proceed with Flipnote Lenny.  
+However, if for whatever reason you have a functional copy of Flipnote Studio and prefer use it instead of DSi Camera, you may proceed with Flipnote Lenny.
 Continue to [Installing Unlaunch (Flipnote)](installing-unlaunch-legacy)
 {: .notice--info}
 

--- a/_pages/en_US/installing-hiyacfw.md
+++ b/_pages/en_US/installing-hiyacfw.md
@@ -55,13 +55,21 @@ HiyaCFW has several advantages that only having Unlaunch on your system will not
   - Unlaunch's GUI should appear
 14. Navigate to `OPTIONS`, and press (A)
 15. Press (A) to configure a default software to boot in to when no button is held
-16. Navigate to `HIYACFW`, and press (A)
+16. Navigate to `hiyaCFW`, and press (A)
 17. Navigate to `SAVE & EXIT`, and press (A)
 18. Power off your console, and turn it back on
   - HiyaCFW's settings screen should appear
 19. Change the settings to your liking, and press (START) to continue
-  - If you boot to "An error has occured" screen, it's most likely because your SD card is larger than 2GB; follow [Replacing System Menu with TWiLight Menu++](replacing-system-menu-with-twilight-menu++) to work around this issue
+  - If you boot to "An error has occured" screen, it's most likely because your SD card has more than 2GB of free space
+  - To fix this you can create dummy files to fill up your SD card, use the following command for your OS to create 1GB files until your SD has less than 2GB free, changing `dummy0` to another name for each one:
+    - Windows:<br>
+    `fsutil file createnew dummy0 1073741824`
+    - Linux/macOS:<br>
+    `dd if=/dev/zero of=dummy0 count=1024 bs=1048576`
 
 Your system will now boot from the SD card instead of the internal NAND.
 
 If you want to boot in to the internal storage, you may configure `LAUNCHER` to a hotkey in a similar manner to the one you just did for HiyaCFW.
+
+If you'd like to install TWiLight Menu ++, continue to [Installing TWiLight Menu++](installing-twilight-menu++)
+{: .notice--info}

--- a/_pages/en_US/installing-twilight-menu++.md
+++ b/_pages/en_US/installing-twilight-menu++.md
@@ -26,10 +26,22 @@ TWiLightMenu++ is an open-source & customizable alternative to the Nintendo DSi'
 3. Copy the `_nds` and `roms` folders to the root of your SD card
 4. Copy the `_nds` folder and `boot.nds` file from `DSi&3DS - SD card users` folder to the root of your SD card
     - On Windows, merge files when asked to
-5. Power on your system
+5. If using HiyaCFW, Power on your system. Otherwise continue on to [Replacing the System Menu](replacing-the-system-menu-if-not-using-hiyacfw)
     - TWiLight Menu++ should now be a DSiWare on your system
 
-TWiLight Menu++ should now be on your System Menu, as any other DSiWare would be.
+## Replacing the System Menu (If not using HiyaCFW)
+
+You must have [Unlaunch](/guide/installing-unlaunch/) installed before proceeding.
+{: .notice--info}
+
+1. Power on your DSi while holding **A** and **B**
+14. Navigate to `OPTIONS`, and press (A)
+15. Press (A) to configure a default software to boot in to when no button is held
+16. Navigate to the first `TWiLight Menu++`, and press (A)
+  - It should say `sdmc:/boot.nds` on the bottom screen
+17. Navigate to `SAVE & EXIT`, and press (A)
+
+TWiLight Menu++ is now your System Menu. If you want to run DSiWare, wait for steps on how to run them to appear.
 
 ## Usage
 
@@ -37,23 +49,13 @@ TWiLight Menu++ should now be on your System Menu, as any other DSiWare would be
   - Place Gameboy roms in `/roms/gb`
   - Place NDS roms in `/roms/nds`
   - Place NES roms in `/roms/nes`
-  - For GBA, make a folder in `roms` named `gba` and place roms there
-  - GBA requires a copy of the GBA BIOS named `bios.bin` on the root of your SD card
-2. Launch TWiLight Menu++ from the Home Menu
-3. You will now see a list of your NDS ROMs
-  - Press (A) to launch ROMs
-  - Touch the GBA icon, which starts GBARunner2, to run GBA ROMs
-  - Touch the HOME icon to return to the DSi Menu
-4. (optional) If you have Unlaunch and HiyaCFW, TWiLight Menu++ can completely replace your System Menu. This can help work around several bugs with SD card sizes and the DSiWare block limit.
-
-## (optional) Replacing the System Menu
-
-You must have [Unlaunch](/guide/installing-unlaunch/) and [HiyaCFW](/guide/installing-hiyacfw/) installed before proceeding.
-{: .notice--info}
-
-1. Power on your DSi while holding **SELECT**
-2. If `Autoboot title` is not checked, navigate to it and press **A**
-3. Press **START** to save and continue booting
-    - TWiLight Menu++ will appear
-
-TWiLight Menu++ is now your System Menu. If you want to run DSiWare, wait for steps on how to run them to appear.
+  - For GBA, make a folder in the root of your SD named `gba` and place roms there
+  - GBA requires a copy of the GBA BIOS named `bios.bin` on the root of your SD card, in `sd:/gba` or in `sd:/_gba`
+  - Note: Using these folders in not required, it is simply a recommended way to organize your games
+2. Power on your DSi
+3. If using HiyaCFW, Launch TWiLight Menu++ from the Home Menu
+4. You will now see a list of files and folders in the root of your SD
+  - Press (A) to launch ROMs and enter folders
+  - Press Select, then choose `Launch GBARunner2` to play GBA games
+  - Press Select, then choose `DSi Menu` to go to the DSi Menu
+  - You will need to configure your launcher version in TWiLight Menu++ settings if not using HiyaCFW

--- a/_pages/en_US/installing-unlaunch-legacy.md
+++ b/_pages/en_US/installing-unlaunch-legacy.md
@@ -18,7 +18,7 @@ Before proceeding, if your system region is USA, make sure your console language
 Ensure your SD card is formatted to FAT32 before proceeding.
 {: .notice--info}
 
-Unlaunch is a DSi bootcode exploit which will allow you to install HiyaCFW, a DSi Custom Firmware, to your console.
+Unlaunch is a DSi bootcode exploit which will allow you to run HiyaCFW, a DSi Custom Firmware, and homebrew with full access to your console.
 ## Downloads
 - The latest release of [Unlaunch](https://problemkaputt.de/unlaunch.zip){:target="_blank"}
 - The latest release of [HBMenu](https://github.com/devkitPro/nds-hb-menu/releases/){:target="_blank"}
@@ -32,7 +32,6 @@ Unlaunch is a DSi bootcode exploit which will allow you to install HiyaCFW, a DS
 4. Copy `BOOT.NDS` from the `hbmenu` folder in the HBMenu `.tar.bz2` file to the root of your SD card
 5. Eject your SD card, and insert it back into your DSi
 
-<a name="creating-a-nand-backup"/>
 ## Creating a NAND backup
 
 1. Open the Flipnote Studio application
@@ -76,7 +75,20 @@ Unlaunch is a DSi bootcode exploit which will allow you to install HiyaCFW, a DS
 9. Power on your system, to verify Unlaunch installed properly
   - You should now see Unlaunch's management screen
 
-With Unlaunch installed, your system now has primitive brick protection, unless the launcher's TMD file is destroyed. Unlaunch has protections that should prevent this from happening, and HiyaCFW uses your SD card as the DSi's NAND, adding a very resilient layer of brick protection.
+With Unlaunch installed, your system now has primitive brick protection, unless the launcher's TMD file is destroyed, which Unlaunch has protections to prevent from happening.
 
-Continue to [Installing HiyaCFW](installing-hiyacfw)
+---
+
+You may now choose whether you would like to install HiyaCFW, or only TWiLight Menu++.
+
+TWiLightMenu++ is an open-source & customizable alternative to the Nintendo DSi's System Menu. It can be used as a frontend for either nds-bootstrap or supported flashcards. It also provides a unified interface for launching NES, SNES, Gameboy (Color), SEGA GameGear, SEGA Genesis, Nintendo DS & DSiWare titles.
+
+HiyaCFW is a custom firmware that will allow you to install custom titles to your home menu using your SD card as an SDNAND to prevent dangerous writing to the system's internal NAND storage.
+
+If you install HiyaCFW you can also install TWiLight Menu++ if you'd like, however HiyaCFW requires you to fill your SD so that less than 2GB are free and will boot slowly on larger cards. Installing HiyaCFW will also require a computer with Windows, macOS, or Linux.
+
+Continue to [Installing only TWiLight Menu++](installing-twilight-menu++)
+{: .notice--info}
+
+Continue to [Installing HiyaCFW (and optionally TWiLight Menu++)](installing-hiyacfw)
 {: .notice--info}

--- a/_pages/en_US/installing-unlaunch.md
+++ b/_pages/en_US/installing-unlaunch.md
@@ -15,7 +15,7 @@ Before starting, you may want to check your SD card for errors using [H2testw (W
 Ensure your SD card is formatted to FAT32 before proceeding.
 {: .notice--info}
 
-Unlaunch is a DSi bootcode exploit which will allow you to install HiyaCFW, a DSi Custom Firmware, to your console.
+Unlaunch is a DSi bootcode exploit which will allow you to run HiyaCFW, a DSi Custom Firmware, and homebrew with full access to your console.
 ## Downloads
 - The latest release of [Unlaunch](https://problemkaputt.de/unlaunch.zip){:target="_blank"}
 - The latest release of [HBMenu](https://github.com/devkitPro/nds-hb-menu/releases/){:target="_blank"}
@@ -35,7 +35,6 @@ Unlaunch is a DSi bootcode exploit which will allow you to install HiyaCFW, a DS
   - If it doesn't exist, take a photo on the console and copy it to the SD card
 5. Eject your SD card, and insert it back into your DSi
 
-<a name="creating-a-nand-backup"/>
 ## Creating a NAND backup
 
 1. Open the DSi Camera application
@@ -72,7 +71,20 @@ SHA1 hash of the `nand.bin` will not match the hash stored in `nand.bin.sha1`. T
 9. Power on your system, to verify Unlaunch installed properly
   - You should now see Unlaunch's management screen
 
-With Unlaunch installed, your system now has primitive brick protection, unless the launcher's TMD file is destroyed. Unlaunch has protections that should prevent this from happening, and HiyaCFW uses your SD card as the DSi's NAND, adding a very resilient layer of brick protection.
+With Unlaunch installed, your system now has primitive brick protection, unless the launcher's TMD file is destroyed, which Unlaunch has protections to prevent from happening.
 
-Continue to [Installing HiyaCFW](installing-hiyacfw)
+---
+
+You may now choose whether you would like to install HiyaCFW, or only TWiLight Menu++.
+
+TWiLightMenu++ is an open-source & customizable alternative to the Nintendo DSi's System Menu. It can be used as a frontend for either nds-bootstrap or supported flashcards. It also provides a unified interface for launching NES, SNES, Gameboy (Color), SEGA GameGear, SEGA Genesis, Nintendo DS & DSiWare titles.
+
+HiyaCFW is a custom firmware that will allow you to install custom titles to your home menu using your SD card as an SDNAND to prevent dangerous writing to the system's internal NAND storage.
+
+If you install HiyaCFW you can also install TWiLight Menu++ if you'd like, however HiyaCFW requires you to fill your SD so that less than 2GB are free and will boot slowly on larger cards. Installing HiyaCFW will also require a computer with Windows, macOS, or Linux.
+
+Continue to [Installing only TWiLight Menu++](installing-twilight-menu++)
+{: .notice--info}
+
+Continue to [Installing HiyaCFW (and optionally TWiLight Menu++)](installing-hiyacfw)
 {: .notice--info}


### PR DESCRIPTION
Since HiyaCFW is no longer required for nds-bootstrap to work and there's a few disadvantages to using it (slow boots, problems on large cards, requires a computer) I tried updating the guide to have a TWiLight only way.

Please let me know if there's anything you think I should change, I can host this on my MacBook if you want to see it on the site before merging, I had it up for a while but no one said anything on the TWL Mode Hacking Discord