### PR TITLE
Add a link to the memory pit guide to the bottom

### DIFF
--- a/_pages/en_US/credits.md
+++ b/_pages/en_US/credits.md
@@ -4,35 +4,37 @@ title: "Credits"
 
 If I forgot you here, contact me and I'll add your name.
 
-{% capture notice-1 %}<pre>
-
-    + jerbear64
-    + pokecraft98
-    + emiyl
-    + RocketRobz
-    + Jhynjhiruu
-    + GhostLatte
-    + HamBone41801
-    + CatmanFan
-    + LukeHasAWii
-    + ThisIsDaAccount
-    + pandavova
-    + MyDePain
-    + Hectortillo
-    + TipsPROmayB
-    + Clyde_271
-    + BlastedGuy9905
-    + Flashed
-    + CloudMcFox
-    + mariogamer
-    + Fra
-    + takusan
-    + smileyhead
-    + Plailect
-	+ WinterMute
-	+ shutterbug2000
-	+ zoogie
-
-</pre>{% endcapture %}
+{% capture notice-1 %}
+- jerbear64
+- pokecraft98
+- emiyl
+- RocketRobz
+- Jhynjhiruu
+- GhostLatte
+- HamBone41801
+- CatmanFan
+- LukeHasAWii
+- ThisIsDaAccount
+- pandavova
+- MyDePain
+- Hectortillo
+- TipsPROmayB
+- Clyde_271
+- BlastedGuy9905
+- Flashed
+- CloudMcFox
+- mariogamer
+- Fra
+- takusan
+- smileyhead
+- Plailect
+- WinterMute
+- shutterbug2000
+- zoogie
+- Evie11
+- NightScript
+{% endcapture %}
 
 <div class="notice">{{ notice-1 | markdownify }}</div>
+
+You could contribute to our guide too by simply sending in a Pull Request!

--- a/_pages/en_US/faq.md
+++ b/_pages/en_US/faq.md
@@ -14,10 +14,10 @@ redirect_from:
 
 **A:** Yes. Follow Gadorach's [hardmodding guide](https://gbatemp.net/threads/dsi-downgrading-the-complete-guide.393682/){:target="_blank"} to hardmod your DSi. Previous soldering experience is required.
 
-<a name="faq_2gbsd" />**Q:** Can I use an SD card higher than 2GB with HiyaCFW yet?
+<a name="faq_2gbsd" />**Q:** Why do I boot into "An Error Has Occurred" when I use hiyaCFW with the default DSi Menu, and how can I fix it?
 {: .notice--info}
 
-**A:** Yes, using TWiLight Menu++. See the [Replacing System Menu with TWiLight Menu++](replacing-system-menu-with-twlmenu++) page for more information. Low-level "full" formatting your SD card with a tool like GUIFormat can help as well, but this will not get you around the DSi Menu's block limit, whereas TWiLight Menu++ does.
+**A:** The reason that the DSi Menu throws an error is due to a signed integer overflow. It detects the amount of free space available, but when it goes above a certain value, it goes back to the lowest. Unfortunately, since it's a signed integer, it goes into a negative number. This is fine on an actual NAND, since the NAND size will never go above 128 MB. However, with NAND redirection to the SD card, it does go over the max limit. In order to work around this, you'd have to either use a replacement menu or adjust the free size to accomodate. You could do the latter by either creating dummy files or partitioning your SD card. The recommended way is to simply replace your system menu with [TWiLight Menu++](installing-twilight-menu++) though, as it's a full replacement of the System Menu with much more functionality (Custom Themes and an all-in-one GUI for emulators).
 
 <a name="faq_notwlmenupp" />**Q:** Why don't I see TWiLight Menu++?
 {: .notice--info}

--- a/_pages/en_US/home.md
+++ b/_pages/en_US/home.md
@@ -20,8 +20,6 @@ Thoroughly read all of the introductory pages (including this one!) before proce
 Translators, please help us with translations. Join our [Crowdin Project](https://crowdin.com/project/dsi-guide) to translate this guide to other languages.
 {: .notice--info}
 
-<div class="notice--info">{{ notice-1 | markdownify }}</div>
-
 ## What is homebrew?
 
 Homebrew applications are custom, user-made software, which haven't been authorised by Nintendo. This can include save editing tools, games, emulators, and more.
@@ -41,3 +39,6 @@ This guide will install Unlaunch, a bootrom exploit for the Nintendo DSi. It rem
 - Make sure your console is decently charged when following this process. A sudden power loss could result in serious damage.
 - The recommended method is to use Memory Pit, a DSi Camera exploit for all retail systems, firmware versions and regions. However, if it doesn't work and you have a functioning copy of Flipnote Studios, you could try using [Flipnote Lenny](installing-unlaunch-legacy)
 - You will need an SD card to follow this guide
+
+Continue to the [Memory Pit Guide](installing-unlaunch).
+{: .notice--info}


### PR DESCRIPTION
Consistent with other `hacks.guide` guides, makes sense that you have a link after reading and Evie11 requested this