### PR TITLE
More updates

### DIFF
--- a/_pages/en_US/home.md
+++ b/_pages/en_US/home.md
@@ -31,14 +31,16 @@ Homebrew can be run for free on any DSi system, regardless of firmware version o
 This guide will install Unlaunch, a bootrom exploit for the Nintendo DSi. It removes RSA, whitelist and region checks, allowing you to run any DSi executable on your console. Additionally, you can install hiyaCFW and/or TWiLight Menu++:
 
 - hiyaCFW is a custom firmware for the DSi allowing you to redirect your NAND to the SD card and have a launch splash before boot.
-- TWiLight Menu++ is a homebrew made by RocketRobz that can act as a home menu replacement. It has many additional features, such as custom themes and file management. It's also an all in one menu for different many emulators, such as .nds file loading with nds-bootstrap.
+- TWiLight Menu++ is an open-source homebrew application developed by RocketRobz that can act as a home menu replacement. It has many additional features, such as custom themes and file management. It's also an all in one menu for different many emulators, such as .nds file loading with nds-bootstrap.
 
 ## What should I know before starting?
 
 - Homebrew allows you to modify your system, which could easily result in a brick if done improperly
 - Make sure your console is decently charged when following this process. A sudden power loss could result in serious damage.
 - The recommended method is to use Memory Pit, a DSi Camera exploit for all retail systems, firmware versions and regions. However, if it doesn't work and you have a functioning copy of Flipnote Studios, you could try using [Flipnote Lenny](installing-unlaunch-legacy)
-- You will need an SD card to follow this guide
+- You will need a FAT32-Formatted SD card formatted with a 32kb cluster size to follow this guide
+ - Be sure to check your SD card for errors. You can do so by using [H2testw for Windows](h2testw-(windows)), [F3 for Linux](f3-(linux)) or [F3X for Mac](f3x-(mac))
+- On Windows, it's recommended to [show file extentions](file-extensions-(windows)) if you are using the default File Explorer.
 
 Continue to the [Memory Pit Guide](installing-unlaunch).
 {: .notice--info}

--- a/_pages/en_US/installing-unlaunch.md
+++ b/_pages/en_US/installing-unlaunch.md
@@ -33,7 +33,7 @@ The source code is not needed. You only need the actual files.
 
 ## Launching the exploit
 
-If this method doesn't work, you could use [Flipnote Lenny](installing-unlaunch-legacy) instead, provided you have Flipnote Stuido.
+If this method doesn't work, you could use [Flipnote Lenny](installing-unlaunch-legacy) instead, provided you have Flipnote Studio.
 
 1. Open the DSi Camera application
   - If you already have another DSiWare exploit installed, open that and skip to step 4

--- a/_pages/en_US/installing-unlaunch.md
+++ b/_pages/en_US/installing-unlaunch.md
@@ -6,21 +6,11 @@ redirect_from:
 
 {% include toc title="Table of Contents" %}
 
-Before starting, Windows users should enable the option to show file extensions using [File Extensions (Windows)](file-extensions-(windows))!
-{: .notice--primary}
-
-Before starting, you may want to check your SD card for errors using [H2testw (Windows)](h2testw-(windows)), [F3 (Linux)](f3-(linux)), or [F3X (Mac)](f3x-(mac))!
-{: .notice--primary}
-
-Ensure your SD card is formatted to FAT32 before proceeding.
-{: .notice--info}
-
-Unlaunch is a DSi bootcode exploit which will allow you to run HiyaCFW, a DSi Custom Firmware, and homebrew with full access to your console.
 ## Downloads
 - The latest release of [Unlaunch](https://problemkaputt.de/unlaunch.zip){:target="_blank"}
 - The latest release of [HBMenu](https://github.com/devkitPro/nds-hb-menu/releases/){:target="_blank"}
 - The latest release of [Flipnote ( ͡° ͜ʖ ͡°) ("Flipnote Lenny")](https://davejmurphy.com/͡-͜ʖ-͡/){:target="_blank"}
-  - We are only using this archive for fwTool- a copy of Flipnote Studio is **not** required
+  - We are only using this archive for fwTool; a copy of Flipnote Studio is **not** required
 - The latest release of Memory Pit
   - [for firmware 1.0 - 1.3   (USA, EUR, AUS, JPN)](https://github.com/emiyl/dsi.cfw.guide/raw/master/assets/files/memory_pit/256/pit.bin){:target="_blank"}
   - [for firmware 1.4 - 1.4.5 (USA, EUR, AUS, JPN)](https://github.com/emiyl/dsi.cfw.guide/raw/master/assets/files/memory_pit/768_1024/pit.bin){:target="_blank"}
@@ -33,9 +23,13 @@ Unlaunch is a DSi bootcode exploit which will allow you to run HiyaCFW, a DSi Cu
 3. Copy `BOOT.NDS` from the `hbmenu` folder in the HBMenu `.tar.bz2` file to the root of your SD card
 4. Copy Memory Pit (`pit.bin`) to the `private/ds/app/484E494A` folder on your SD card
   - If it doesn't exist, take a photo on the console and copy it to the SD card
-5. Eject your SD card, and insert it back into your DSi
+5. Copy `UNLAUNCH.DSI` from the Unlaunch `.zip` file to the root of your SD card
+6. Rename `UNLAUNCH.DSI` to `unlaunch.nds`
+7. Eject your SD card, and insert it back into your DSi
 
-## Creating a NAND backup
+## Launching the exploit
+
+If this method doesn't work, you could use [Flipnote Lenny](installing-unlaunch-legacy) instead, provided you have Flipnote Stuidos.
 
 1. Open the DSi Camera application
   - If you already have another DSiWare exploit installed, open that and skip to step 4
@@ -43,35 +37,28 @@ Unlaunch is a DSi bootcode exploit which will allow you to run HiyaCFW, a DSi Cu
 2. Select `SD Card` at the top right
 3. Tap `Album`
   - This will launch HBMenu
-4. Navigate to `fwTool.nds`, and press (A)
-  - fwTool will appear
-5. Navigate to `Backup DSi NAND`, and press (A)
+
+## Creating a NAND Backup
+
+1. Launch `fwTool.nds`
+2. Navigate to `Backup DSi NAND`
   - This will take a few minutes
-  - Store this NAND backup in a safe location, it is a critical backup and we will need it later to install HiyaCFW
   - When `saved nand.bin.sha1.` appears, the backup is finished
-6. Navigate to `Exit`, press (A), and power off your system
+3. Navigate to `Exit`
 
 SHA1 hash of the `nand.bin` will not match the hash stored in `nand.bin.sha1`. This is because fwTool adds additional data to the `nand.bin` file after the SHA1 hash is calculated. You can use the [HiyaCFW Helper](https://github.com/mondul/HiyaCFW-Helper/releases){:target="_blank"} to create a copy without the footer.
 {: .notice--info}
 
+Store this NAND backup in a safe location; it's a failsafe if you mess up. You would also need it if you'd like to install hiyaCFW.
+
 ## Installation
-1. Insert your system's SD card into your computer
-2. Copy `UNLAUNCH.DSI` from the Unlaunch `.zip` file to the root of your SD card
-3. Rename `UNLAUNCH.DSI` to `unlaunch.nds`
-4. Unplug your SD card, and insert it in your DSi
-5. Power on your DSi, and repeat steps 1 through 3 in
-[Creating a NAND backup](#creating-a-nand-backup)
-  - HBMenu will appear
-6. Navigate to `unlaunch.nds`, and press (A)
-  - Unlaunch's installer will appear
-7. Navigate to `INSTALL NOW` and press (A)
-  - If Unlaunch freezes at `ERROR: MISMATCH IN FAT COPIES`, please read our [FAQ](/help/faq)
-8. When done, navigate to `POWER DOWN` and press (A)
-  - Your system will power off
-9. Power on your system, to verify Unlaunch installed properly
+1. Launch `unlaunch.nds`
+2. Navigate to `INSTALL NOW`
+  - If Unlaunch freezes at `ERROR: MISMATCH IN FAT COPIES`, please read our [FAQ](/faq)
+3. When completed, Reboot (power down and power back on) your system in order to verify Unlaunch installed properly.
   - You should now see Unlaunch's management screen
 
-With Unlaunch installed, your system now has primitive brick protection, unless the launcher's TMD file is destroyed, which Unlaunch has protections to prevent from happening.
+If you see Unlaunch's management screen, you have successfully installed Unalunch. With Unlaunch installed, your system now has primitive brick protection.
 
 ---
 

--- a/_pages/en_US/installing-unlaunch.md
+++ b/_pages/en_US/installing-unlaunch.md
@@ -33,7 +33,7 @@ The source code is not needed. You only need the actual files.
 
 ## Launching the exploit
 
-If this method doesn't work, you could use [Flipnote Lenny](installing-unlaunch-legacy) instead, provided you have Flipnote Stuidos.
+If this method doesn't work, you could use [Flipnote Lenny](installing-unlaunch-legacy) instead, provided you have Flipnote Stuido.
 
 1. Open the DSi Camera application
   - If you already have another DSiWare exploit installed, open that and skip to step 4

--- a/_pages/en_US/installing-unlaunch.md
+++ b/_pages/en_US/installing-unlaunch.md
@@ -7,6 +7,10 @@ redirect_from:
 {% include toc title="Table of Contents" %}
 
 ## Downloads
+
+The source code is not needed. You only need the actual files.
+{: .notice--info}
+
 - The latest release of [Unlaunch](https://problemkaputt.de/unlaunch.zip){:target="_blank"}
 - The latest release of [HBMenu](https://github.com/devkitPro/nds-hb-menu/releases/){:target="_blank"}
 - The latest release of [Flipnote ( ͡° ͜ʖ ͡°) ("Flipnote Lenny")](https://davejmurphy.com/͡-͜ʖ-͡/){:target="_blank"}


### PR DESCRIPTION
1. Move SD card formatting to home
2. Specify when another exploit is allowed to be used instead of Memory Pit
3. Copy Unlaunch files the first time around
4. Separate Memory Pit with NAND Backup Steps
5. Much less spoon-feedy
6. Add notice on what needs to be download (aka not the source code)