### PR TITLE
Fix hiyaCFW link

### DIFF
--- a/_data/navigation/en_US.yml
+++ b/_data/navigation/en_US.yml
@@ -17,7 +17,7 @@ main:
     url: installing-twilight-menu++
   -
     title: hiyaCFW
-    url: installing-hiyaCFW
+    url: installing-hiyacfw
 bottom:
   -
     title: If you need help, ask the <a href="https://discord.gg/XRXjzY5">NDS(i)Brew Scene</a> or the <a href="https://discord.gg/yD3spjv">TWL Mode Hacking</a> Discord servers.


### PR DESCRIPTION
or should I say, hiyacfw*

Apparently, these titles are case sensitive. I find that dumb but I'm not sure how to change it